### PR TITLE
package.json: add homepage/repository fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "hnsw",
   "version": "1.0.2",
   "description": "A TypeScript implementation of HNSW (Hierarchical Navigable Small World) algorithm for approximate nearest neighbor search",
+  "homepage": "https://github.com/deepfates/hnsw#readme",
+  "repository": {
+    "type": "git",
+		"url": "git+https://github.com/deepfates/hnsw.git"
+	},
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The current npm package: https://www.npmjs.com/package/hnsw

.....doesn't have any links to this source code repository.

I only found this by doing an Internet search for a string from your README.

Including these links will ensure people can find the source code to fully understand how your API works, since it is unclear from your same what `200, 16` means when you do `new HNSW(..., "cosine")`.