### PR TITLE
Harden production quality gates and persistence reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Coverage Threshold
+        run: npm run test:coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog,
+and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+- CI workflow for build, lint, test, and coverage.
+- Persistence-focused test coverage for IndexedDB-backed index behavior.
+- API reference and tuning guidance in README.
+
+### Changed
+- Lint gate now targets published library sources (`src/**`, excluding benchmark CLI code).
+- README persistence example now loads from the same DB name it saved to.
+
+### Fixed
+- `HNSWWithDB.deleteIndex()` now awaits DB re-initialization.
+- `HNSWWithDB` now surfaces initialization/load/delete errors instead of silently swallowing them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ Thanks for taking the time to improve this HNSW implementation. The checklist be
 - Add or update tests under `tests/` that capture the bug fix or feature so regressions are caught automatically. The `tests/HNSW.test.ts` suite shows how to build deterministic indices for verification.
 - Before committing, run the full set of quality gates:
   - `npm test` – runs the Jest harness
-  - `npm run lint` – checks the TypeScript sources with TSLint
+  - `npm run lint` – checks published TypeScript sources with TSLint
+  - `npm run lint:bench` – optional lint pass for benchmark CLI sources
   - `npm run build` – ensures the TypeScript compiler can emit the distributable files
 
 ## 4. Commit with context

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 deepfates.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,7 +1,15 @@
 {
-    "transform": {
-      "^.+\\.(t|j)sx?$": "ts-jest"
-    },
-    "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+  "transform": {
+    "^.+\\.(t|j)sx?$": "ts-jest"
+  },
+  "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
+  "coverageThreshold": {
+    "global": {
+      "branches": 65,
+      "functions": 80,
+      "lines": 80,
+      "statements": 80
+    }
   }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.1",
+        "@types/node": "^20.11.30",
+        "fake-indexeddb": "^6.2.5",
         "jest": "^29.5.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.0",
@@ -1059,10 +1061,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
-      "dev": true
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -1668,6 +1674,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3620,6 +3636,13 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.3",
   "description": "A TypeScript implementation of HNSW (Hierarchical Navigable Small World) algorithm for approximate nearest neighbor search",
   "homepage": "https://github.com/deepfates/hnsw#readme",
+  "bugs": {
+    "url": "https://github.com/deepfates/hnsw/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/deepfates/hnsw.git"
@@ -11,13 +14,15 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest --config jestconfig.json",
+    "test:coverage": "jest --config jestconfig.json --coverage --runInBand",
     "build": "tsc",
     "bench": "node dist/bench/run.js",
     "bench:download": "node dist/bench/download.js",
     "bench:report": "node dist/bench/report.js",
     "bench:compare": "node dist/bench/compare.js",
     "format": "prettier --write \"src/**/*.ts\"",
-    "lint": "tslint -p tsconfig.json",
+    "lint": "tslint -p tsconfig.lint.json",
+    "lint:bench": "tslint -p tsconfig.json src/bench/**/*.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
@@ -26,7 +31,12 @@
   },
   "keywords": [
     "nearest neighbor",
-    "vector search"
+    "vector search",
+    "hnsw",
+    "ann",
+    "similarity search",
+    "indexeddb",
+    "browser"
   ],
   "author": "deepfates.com",
   "license": "MIT",
@@ -36,6 +46,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.1",
     "@types/node": "^20.11.30",
+    "fake-indexeddb": "^6.2.5",
     "jest": "^29.5.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,9 @@ export class HNSW {
   nodes: Map<number, Node>; // Map of nodes
   probs: number[]; // Probabilities for the levels
 
+  /**
+   * Creates an in-memory HNSW index.
+   */
   constructor(M = 16, efConstruction = 200, d: number | null = null, metric = 'cosine', efSearch?: number) {
     this.metric = metric as Metric;
     this.d = d;
@@ -225,6 +228,9 @@ export class HNSW {
     }
   }
 
+  /**
+   * Adds a single vector to the graph.
+   */
   async addPoint(id: number, vector: Float32Array | number[]) {
     if (this.d !== null && vector.length !== this.d) {
       throw new Error('All vectors must be of the same dimension');
@@ -241,6 +247,9 @@ export class HNSW {
     await this.addNodeToGraph(node);
   }
 
+  /**
+   * Returns up to k nearest neighbors for the query vector.
+   */
   searchKNN(
     query: Float32Array | number[],
     k: number,
@@ -273,6 +282,9 @@ export class HNSW {
     return results;
   }
 
+  /**
+   * Rebuilds the graph from the provided data.
+   */
   async buildIndex(
     data: { id: number; vector: Float32Array | number[] }[],
     options?: {
@@ -304,6 +316,9 @@ export class HNSW {
     }
   }
 
+  /**
+   * Serializes the current in-memory index.
+   */
   toJSON() {
     const entries = Array.from(this.nodes.entries());
     return {
@@ -328,6 +343,9 @@ export class HNSW {
     };
   }
 
+  /**
+   * Restores an index from serialized JSON produced by toJSON().
+   */
   static fromJSON(json: any): HNSW {
     // efSearch defaults to efConstruction if not present (backward compatibility)
     const hnsw = new HNSW(json.M, json.efConstruction, json.d ?? null, json.metric ?? 'cosine', json.efSearch);

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "tests", "src/bench"]
+}


### PR DESCRIPTION
## Summary
- add production CI workflow (build, lint, test, coverage)
- add release hygiene files (`LICENSE`, `CHANGELOG.md`) and package metadata improvements
- split lint scope to publishable library code via `tsconfig.lint.json` and add optional `lint:bench`
- expand tests from 7 to 12 with persistence and edge-case coverage
- harden `HNSWWithDB` lifecycle: explicit `close()`, delete/reinit sequencing, and explicit uninitialized DB errors
- improve README with API reference, tuning guidance, limitations, and corrected IndexedDB example

## Validation
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:coverage`

## Coverage
- statements: 93.66%
- branches: 74.78%
- functions: 98.3%
- lines: 94.6%
